### PR TITLE
feat: Implement ngrok v1 proxy for serve command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "conf": "12.0.0",
         "http-proxy": "1.18.1",
         "inquirer": "9.2.23",
-        "picocolors": "1.1.0"
+        "picocolors": "1.1.0",
+        "strip-ansi": "7.1.0"
       },
       "bin": {
         "liff-cli": "index.js"
@@ -28,6 +29,7 @@
         "eslint": "8.50.0",
         "eslint-config-prettier": "9.1.0",
         "msw": "2.3.1",
+        "node-pty": "1.0.0",
         "prettier": "3.3.1",
         "publint": "0.2.8",
         "typescript": "5.4.5",
@@ -595,6 +597,27 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@inquirer/core/node_modules/undici-types": {
@@ -1432,11 +1455,14 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -1851,6 +1877,27 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
@@ -2428,6 +2475,15 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2445,6 +2501,18 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -3144,6 +3212,14 @@
         "node": ">=18"
       }
     },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inquirer/node_modules/chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
@@ -3153,6 +3229,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -3650,6 +3737,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "dev": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -3679,6 +3772,16 @@
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
       "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
       "dev": true
+    },
+    "node_modules/node-pty": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.17.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3871,6 +3974,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/os-tmpdir": {
@@ -4683,7 +4805,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4692,6 +4822,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-final-newline": {
@@ -5143,6 +5287,25 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "8.50.0",
     "eslint-config-prettier": "9.1.0",
     "msw": "2.3.1",
+    "node-pty": "1.0.0",
     "prettier": "3.3.1",
     "publint": "0.2.8",
     "typescript": "5.4.5",
@@ -48,6 +49,15 @@
     "conf": "12.0.0",
     "http-proxy": "1.18.1",
     "inquirer": "9.2.23",
-    "picocolors": "1.1.0"
+    "picocolors": "1.1.0",
+    "strip-ansi": "7.1.0"
+  },
+  "peerDependencies": {
+    "node-pty": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "node-pty": {
+      "optional": true
+    }
   }
 }

--- a/src/serve/commands/index.test.ts
+++ b/src/serve/commands/index.test.ts
@@ -19,7 +19,9 @@ describe("serveCommand", () => {
       url: "https://example.com?hoge=fuga",
       host: "https://example.com",
       port: "8000",
+      proxyType: "local-proxy",
       localProxyPort: "9001",
+      ngrokCommand: "ngrok",
       inspect: true,
     };
 
@@ -45,6 +47,10 @@ describe("serveCommand", () => {
       "--local-proxy-port",
       options.localProxyPort,
       "--inspect",
+      "--proxy-type",
+      options.proxyType,
+      "--ngrok-command",
+      options.ngrokCommand,
     ]);
 
     expect(serveAction).toHaveBeenCalledWith(options, proxy);

--- a/src/serve/commands/index.ts
+++ b/src/serve/commands/index.ts
@@ -1,7 +1,6 @@
 import { Command } from "commander";
-import { LocalProxy } from "../proxy/local-proxy.js";
-import path from "path";
 import { serveAction } from "../serveAction.js";
+import { resolveProxy } from "../resolveProxy.js";
 
 export const installServeCommands = (program: Command) => {
   const serve = program.command("serve");
@@ -19,17 +18,22 @@ export const installServeCommands = (program: Command) => {
       "The flag indicates LIFF app starts on debug mode. (default: false)",
     )
     .option(
+      "--proxy-type <proxyType>",
+      "The type of proxy to use. local-proxy or ngrok-v1",
+      "local-proxy",
+    )
+    .option(
       "--local-proxy-port <localProxyPort>",
       "The port number of the application proxy server to listen on when running the CLI.",
       "9000",
     )
+    .option(
+      "--ngrok-command <ngrokCommand>",
+      "The command to run ngrok.",
+      "ngrok",
+    )
     .action(async (options) => {
-      const cwd = process.cwd();
-      const proxy = new LocalProxy({
-        keyPath: path.resolve(cwd, "localhost-key.pem"),
-        certPath: path.resolve(cwd, "localhost.pem"),
-        port: options.localProxyPort,
-      });
+      const proxy = resolveProxy(options);
       await serveAction(options, proxy);
     });
   return serve;

--- a/src/serve/proxy/ngrok-v1-proxy.ts
+++ b/src/serve/proxy/ngrok-v1-proxy.ts
@@ -1,0 +1,68 @@
+import { setTimeout } from "node:timers";
+import os from "node:os";
+
+import stripAnsi from "strip-ansi";
+import type pty from "node-pty";
+
+import { ProxyInterface } from "./proxy-interface.js";
+
+function extractUrl(input: string): string | null {
+  const urlRegex = /(https:\/\/[^\s]+)->/;
+  const match = input.match(urlRegex);
+  return match ? match[1] : null;
+}
+
+type NgrokV1ProxyConfig = {
+  ngrokCommand: string;
+};
+
+async function tryImportNodePty(): Promise<typeof pty> {
+  try {
+    return (await import("node-pty")).default;
+  } catch (error) {
+    throw new Error(`Failed to import 'node-pty'. Please install it manually.`);
+  }
+}
+
+export class NgrokV1Proxy implements ProxyInterface {
+  private ptyProcess?: pty.IPty;
+
+  constructor(private config: NgrokV1ProxyConfig) {}
+
+  async connect(targetUrl: URL): Promise<URL> {
+    const targetPort = targetUrl.port;
+
+    const command = `${this.config.ngrokCommand} ${targetPort}`;
+
+    const shell = os.platform() === "win32" ? "powershell.exe" : "bash";
+    const pty = await tryImportNodePty();
+    this.ptyProcess = pty.spawn(shell, [], {
+      name: "xterm-color",
+      cols: 80,
+      rows: 30,
+      cwd: process.env.HOME,
+      env: process.env,
+    });
+
+    const promise = new Promise<URL>((resolve, reject) => {
+      this.ptyProcess?.onData((data) => {
+        const url = extractUrl(stripAnsi(data));
+        if (url) {
+          resolve(new URL(url));
+        }
+      });
+
+      setTimeout(() => {
+        reject(new Error("Not found ngrok URL from the output."));
+      }, 10000);
+    });
+
+    this.ptyProcess?.write(command + "\r");
+
+    return promise;
+  }
+
+  async cleanup(): Promise<void> {
+    this.ptyProcess?.kill();
+  }
+}

--- a/src/serve/proxy/proxy-interface.ts
+++ b/src/serve/proxy/proxy-interface.ts
@@ -1,3 +1,4 @@
+import { URL } from "node:url";
 export interface ProxyInterface {
   connect(targetUrl: URL): Promise<URL>;
   cleanup(): Promise<void>;

--- a/src/serve/resolveEndpointUrl.ts
+++ b/src/serve/resolveEndpointUrl.ts
@@ -1,4 +1,4 @@
-import { URL } from "url";
+import { URL } from "node:url";
 
 export const resolveEndpointUrl = ({
   url,

--- a/src/serve/resolveProxy.test.ts
+++ b/src/serve/resolveProxy.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { resolveProxy } from "./resolveProxy.js";
+import { LocalProxy } from "./proxy/local-proxy.js";
+import { NgrokV1Proxy } from "./proxy/ngrok-v1-proxy.js";
+
+describe("resolveProxy", () => {
+  it("should return LocalProxy when proxyType is local-proxy", () => {
+    const options = {
+      proxyType: "local-proxy",
+      localProxyPort: "9000",
+      ngrokCommand: "ngrok",
+    };
+
+    expect(resolveProxy(options)).toBeInstanceOf(LocalProxy);
+  });
+
+  it("should return NgrokV1Proxy when proxyType is ngrok-v1", () => {
+    const options = {
+      proxyType: "ngrok-v1",
+      localProxyPort: "9000",
+      ngrokCommand: "ngrok",
+    };
+
+    expect(resolveProxy(options)).toBeInstanceOf(NgrokV1Proxy);
+  });
+
+  it("should throw an error when an unknown proxyType is specified", () => {
+    const options = {
+      proxyType: "unknown",
+      localProxyPort: "9000",
+      ngrokCommand: "ngrok",
+    };
+
+    expect(() => resolveProxy(options)).toThrow("Unknown proxy type: unknown");
+  });
+});

--- a/src/serve/resolveProxy.ts
+++ b/src/serve/resolveProxy.ts
@@ -1,0 +1,30 @@
+import path from "path";
+
+import { LocalProxy } from "./proxy/local-proxy.js";
+import { NgrokV1Proxy } from "./proxy/ngrok-v1-proxy.js";
+import { ProxyInterface } from "./proxy/proxy-interface.js";
+
+type Options = {
+  proxyType: string;
+  localProxyPort: string;
+  ngrokCommand: string;
+};
+
+export const resolveProxy = (options: Options): ProxyInterface => {
+  if (options.proxyType === "local-proxy") {
+    const cwd = process.cwd();
+    return new LocalProxy({
+      keyPath: path.resolve(cwd, "localhost-key.pem"),
+      certPath: path.resolve(cwd, "localhost.pem"),
+      port: options.localProxyPort,
+    });
+  }
+
+  if (options.proxyType === "ngrok-v1") {
+    return new NgrokV1Proxy({
+      ngrokCommand: options.ngrokCommand,
+    });
+  }
+
+  throw new Error(`Unknown proxy type: ${options.proxyType}`);
+};

--- a/src/serve/serveAction.ts
+++ b/src/serve/serveAction.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { LiffApiClient } from "../api/liff.js";
 import { resolveChannel } from "../channel/resolveChannel.js";
 import { getCurrentChannelId } from "../channel/stores/channels.js";
-import { LocalProxy } from "./proxy/local-proxy.js";
+import { ProxyInterface } from "./proxy/proxy-interface.js";
 import resolveEndpointUrl from "./resolveEndpointUrl.js";
 import pc from "picocolors";
 
@@ -15,7 +15,7 @@ export const serveAction = async (
     inspect?: boolean;
     localProxyPort: string;
   },
-  localProxy: LocalProxy,
+  proxy: ProxyInterface,
 ) => {
   const accessToken = (await resolveChannel(getCurrentChannelId()))
     ?.accessToken;
@@ -47,7 +47,7 @@ export const serveAction = async (
     endpointUrl.searchParams.set("li.origin", "wss://localhost:9222");
   }
 
-  const httpsUrl = await localProxy.connect(endpointUrl);
+  const httpsUrl = await proxy.connect(endpointUrl);
   const liffUrl = new URL("https://liff.line.me/");
   liffUrl.pathname = options.liffId;
 

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -107,9 +107,13 @@ Options:
                                        server.
   -i, --inspect                        The flag indicates LIFF app starts on
                                        debug mode. (default: false)
+  --proxy-type <proxyType>             The type of proxy to use. local-proxy or
+                                       ngrok-v1 (default: "local-proxy")
   --local-proxy-port <localProxyPort>  The port number of the application proxy
                                        server to listen on when running the
                                        CLI. (default: "9000")
+  --ngrok-command <ngrokCommand>       The command to run ngrok. (default:
+                                       "ngrok")
   -h, --help                           display help for command
 `);
   });


### PR DESCRIPTION
## Description
I implemented the integration with [ngrok v1](https://github.com/inconshreveable/ngrok) as one of the integrations for the Tunnel feature.  
This feature uses ngrok to tunnel the URL passed to the serve command, and sets the ngrok URL as the endpoint URL for the LIFF app.

Below is what the terminal looks like when the command is executed:
```
❯ npx @line/liff-cli serve -l 1234567890-aBcDeFg -u http://127.0.0.1:8081 --proxy-type ngrok-v1 --ngrok-command ngrok
Successfully updated endpoint url for LIFF ID: 1234567890-aBcDeFg.

→  LIFF URL:     https://liff.line.me/1234567890-aBcDeFg
→  Proxy server: https://abc123.ngrok.example.com/
```


In order for users to use this feature, they need to install `node-pty`.
`node-pty` is a large package.
ref: https://bundlephobia.com/package/node-pty@1.0.0

Because not all users will use the ngrok v1 integration feature, I specified it in `peerDependencies`.