### PR TITLE
feat: Add proxy for @line/liff-inspector

### DIFF
--- a/src/serve/commands/index.test.ts
+++ b/src/serve/commands/index.test.ts
@@ -21,15 +21,25 @@ describe("serveCommand", () => {
       port: "8000",
       proxyType: "local-proxy",
       localProxyPort: "9001",
+      localProxyInspectorPort: "9223",
       ngrokCommand: "ngrok",
       inspect: true,
     };
 
     const cwd = process.cwd();
-    const proxy = new LocalProxy({
-      keyPath: path.resolve(cwd, "localhost-key.pem"),
-      certPath: path.resolve(cwd, "localhost.pem"),
+    const keyPath = path.resolve(cwd, "localhost-key.pem");
+    const certPath = path.resolve(cwd, "localhost.pem");
+
+    const liffAppProxy = new LocalProxy({
+      keyPath,
+      certPath,
       port: "9001",
+    });
+
+    const liffInspectorProxy = new LocalProxy({
+      keyPath,
+      certPath,
+      port: "9223",
     });
 
     const command = installServeCommands(program);
@@ -46,6 +56,8 @@ describe("serveCommand", () => {
       options.port,
       "--local-proxy-port",
       options.localProxyPort,
+      "--local-proxy-inspector-port",
+      options.localProxyInspectorPort,
       "--inspect",
       "--proxy-type",
       options.proxyType,
@@ -53,6 +65,10 @@ describe("serveCommand", () => {
       options.ngrokCommand,
     ]);
 
-    expect(serveAction).toHaveBeenCalledWith(options, proxy);
+    expect(serveAction).toHaveBeenCalledWith(
+      options,
+      liffAppProxy,
+      liffInspectorProxy,
+    );
   });
 });

--- a/src/serve/commands/index.ts
+++ b/src/serve/commands/index.ts
@@ -28,13 +28,18 @@ export const installServeCommands = (program: Command) => {
       "9000",
     )
     .option(
+      "--local-proxy-inspector-port <localProxyInspectorPort>",
+      "The port number of the inspector proxy server to listen on when running the CLI.",
+      "9223",
+    )
+    .option(
       "--ngrok-command <ngrokCommand>",
       "The command to run ngrok.",
       "ngrok",
     )
     .action(async (options) => {
-      const proxy = resolveProxy(options);
-      await serveAction(options, proxy);
+      const { liffAppProxy, liffInspectorProxy } = resolveProxy(options);
+      await serveAction(options, liffAppProxy, liffInspectorProxy);
     });
   return serve;
 };

--- a/src/serve/proxy/local-proxy.ts
+++ b/src/serve/proxy/local-proxy.ts
@@ -87,7 +87,6 @@ export class LocalProxy implements ProxyInterface {
           proxy.ws(req, socket, head);
         })
         .on("error", (e) => {
-          console.log(e);
           reject(e);
         });
     });

--- a/src/serve/proxy/local-proxy.ts
+++ b/src/serve/proxy/local-proxy.ts
@@ -28,6 +28,18 @@ export class LocalProxy implements ProxyInterface {
   }
 
   async connect(targetUrl: URL): Promise<URL> {
+    if (targetUrl.protocol === "http:") {
+      return this.connectHttp(targetUrl);
+    }
+
+    if (targetUrl.protocol === "ws:") {
+      return this.connectWs(targetUrl);
+    }
+
+    throw new Error(`Unsupported protocol: ${targetUrl.protocol}`);
+  }
+
+  private async connectHttp(targetUrl: URL): Promise<URL> {
     const proxy = httpProxy.createProxyServer({});
 
     const proxyUrl = new URL("https://localhost");
@@ -55,8 +67,34 @@ export class LocalProxy implements ProxyInterface {
     });
   }
 
-  async cleanup(): Promise<void> {
+  private async connectWs(targetUrl: URL): Promise<URL> {
+    const proxy = httpProxy.createProxyServer({ target: targetUrl.toString() });
+
+    const proxyUrl = new URL("wss://localhost");
+    proxyUrl.port = this.port;
+
     return new Promise((resolve, reject) => {
+      this.server = https
+        .createServer({ key: this.key, cert: this.cert }, (req, res) => {
+          proxy.web(req, res);
+        })
+        .listen(this.port)
+        .on("listening", () => {
+          resolve(proxyUrl);
+        })
+        .on("upgrade", function (req, socket, head) {
+          req.headers["x-forwarded-proto"] = "https";
+          proxy.ws(req, socket, head);
+        })
+        .on("error", (e) => {
+          console.log(e);
+          reject(e);
+        });
+    });
+  }
+
+  async cleanup(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
       if (!this.server) {
         resolve();
         return;
@@ -65,6 +103,8 @@ export class LocalProxy implements ProxyInterface {
         if (e) reject(e);
         else resolve();
       });
+    }).finally(() => {
+      this.server = undefined;
     });
   }
 }

--- a/src/serve/resolveProxy.test.ts
+++ b/src/serve/resolveProxy.test.ts
@@ -8,26 +8,35 @@ describe("resolveProxy", () => {
     const options = {
       proxyType: "local-proxy",
       localProxyPort: "9000",
+      localProxyInspectorPort: "9223",
       ngrokCommand: "ngrok",
     };
 
-    expect(resolveProxy(options)).toBeInstanceOf(LocalProxy);
+    expect(resolveProxy(options)).toEqual({
+      liffAppProxy: expect.any(LocalProxy),
+      liffInspectorProxy: expect.any(LocalProxy),
+    });
   });
 
   it("should return NgrokV1Proxy when proxyType is ngrok-v1", () => {
     const options = {
       proxyType: "ngrok-v1",
       localProxyPort: "9000",
+      localProxyInspectorPort: "9223",
       ngrokCommand: "ngrok",
     };
 
-    expect(resolveProxy(options)).toBeInstanceOf(NgrokV1Proxy);
+    expect(resolveProxy(options)).toEqual({
+      liffAppProxy: expect.any(NgrokV1Proxy),
+      liffInspectorProxy: expect.any(NgrokV1Proxy),
+    });
   });
 
   it("should throw an error when an unknown proxyType is specified", () => {
     const options = {
       proxyType: "unknown",
       localProxyPort: "9000",
+      localProxyInspectorPort: "9223",
       ngrokCommand: "ngrok",
     };
 

--- a/src/serve/resolveProxy.ts
+++ b/src/serve/resolveProxy.ts
@@ -7,23 +7,40 @@ import { ProxyInterface } from "./proxy/proxy-interface.js";
 type Options = {
   proxyType: string;
   localProxyPort: string;
+  localProxyInspectorPort: string;
   ngrokCommand: string;
 };
 
-export const resolveProxy = (options: Options): ProxyInterface => {
+export const resolveProxy = (
+  options: Options,
+): { liffAppProxy: ProxyInterface; liffInspectorProxy: ProxyInterface } => {
   if (options.proxyType === "local-proxy") {
     const cwd = process.cwd();
-    return new LocalProxy({
-      keyPath: path.resolve(cwd, "localhost-key.pem"),
-      certPath: path.resolve(cwd, "localhost.pem"),
-      port: options.localProxyPort,
-    });
+    const keyPath = path.resolve(cwd, "localhost-key.pem");
+    const certPath = path.resolve(cwd, "localhost.pem");
+    return {
+      liffAppProxy: new LocalProxy({
+        keyPath,
+        certPath,
+        port: options.localProxyPort,
+      }),
+      liffInspectorProxy: new LocalProxy({
+        keyPath,
+        certPath,
+        port: options.localProxyInspectorPort,
+      }),
+    };
   }
 
   if (options.proxyType === "ngrok-v1") {
-    return new NgrokV1Proxy({
-      ngrokCommand: options.ngrokCommand,
-    });
+    return {
+      liffAppProxy: new NgrokV1Proxy({
+        ngrokCommand: options.ngrokCommand,
+      }),
+      liffInspectorProxy: new NgrokV1Proxy({
+        ngrokCommand: options.ngrokCommand,
+      }),
+    };
   }
 
   throw new Error(`Unknown proxy type: ${options.proxyType}`);

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -100,22 +100,16 @@ Commands:
 Manage HTTPS dev server
 
 Options:
-  -l, --liff-id <liffId>               The LIFF id that the user wants to
-                                       update.
-  -u, --url <url>                      The local URL of the LIFF app.
-  --host <host>                        The host of the application server.
-  --port <port>                        The port number of the application
-                                       server.
-  -i, --inspect                        The flag indicates LIFF app starts on
-                                       debug mode. (default: false)
-  --proxy-type <proxyType>             The type of proxy to use. local-proxy or
-                                       ngrok-v1 (default: "local-proxy")
-  --local-proxy-port <localProxyPort>  The port number of the application proxy
-                                       server to listen on when running the
-                                       CLI. (default: "9000")
-  --ngrok-command <ngrokCommand>       The command to run ngrok. (default:
-                                       "ngrok")
-  -h, --help                           display help for command
+  -l, --liff-id <liffId>                                  The LIFF id that the user wants to update.
+  -u, --url <url>                                         The local URL of the LIFF app.
+  --host <host>                                           The host of the application server.
+  --port <port>                                           The port number of the application server.
+  -i, --inspect                                           The flag indicates LIFF app starts on debug mode. (default: false)
+  --proxy-type <proxyType>                                The type of proxy to use. local-proxy or ngrok-v1 (default: "local-proxy")
+  --local-proxy-port <localProxyPort>                     The port number of the application proxy server to listen on when running the CLI. (default: "9000")
+  --local-proxy-inspector-port <localProxyInspectorPort>  The port number of the inspector proxy server to listen on when running the CLI. (default: "9223")
+  --ngrok-command <ngrokCommand>                          The command to run ngrok. (default: "ngrok")
+  -h, --help                                              display help for command
 `);
   });
 });


### PR DESCRIPTION
# Description
Currently, the serve command’s `--inspect` option in liff-cli executes the `@line/liff-inspector` command with the `--cert` option.
`liff-cli` has a feature that can convert HTTP endpoints into HTTPS.
I used this feature to fix it so that `@line/liff-inspector` can be used without the `--cert` option.

As a result, it is now easier to combine `@line/liff-inspector` with tunneling tools like `ngrok`.


# Usage
## Run `serve` command with `@line/liff-inspector`

```bash
$ npx @line/liff-cli serve -l 1234567890-aBcDeFg -u http://localhost:5173/ --inspect
Debugger listening on ws://192.168.11.3:9222

You need to serve this server over SSL/TLS
For help, see: https://github.com/line/liff-inspector#important-liff-inspector-server-need-to-be-served-over-ssltls


Successfully updated endpoint url for LIFF ID: 1234567890-aBcDeFg.

→  LIFF URL:     https://liff.line.me/1234567890-aBcDeFg
→  Proxy server: https://localhost:9000/?li.origin=wss%3A%2F%2Flocalhost%3A9223%2F
connection from client, id: 1234567890-aBcDeFg
DevTools URL: devtools://devtools/bundled/inspector.html?wss=localhost:9223/?hi_id=1234567890-aBcDeFg
```

## Run `serve` command with `@line/liff-inspector` and `ngrok`

```bash
$ npx @line/liff-cli serve -l 1234567890-aBcDeFg -u http://localhost:5173/ --inspect --proxy-type ngrok-v1
```