### PR TITLE
docs: Add experimental mark to ngrok-v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ mkcert localhost
 
 3. Place the generated `localhost.pem` and `localhost-key.pem` files in the root directory of your project.
 
-##### When using `ngrok-v1`
+#### When using `ngrok-v1`
 
 > [!WARNING]
 > This feature is experimental.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ $ liff-cli scaffold my-liff-app --liff-id 1234567-abcdef
 
 The `serve` command is used to start local dev server with HTTPS and update an endpoint URL.
 
-#### Creating Certificates
+#### When using `local-proxy`
+
+##### Creating Certificates
 
 Before using the `serve` command, you need to create `localhost.pem` and `localhost-key.pem` in the root directory using `mkcert`. Follow these steps:
 
@@ -118,6 +120,13 @@ $ mkcert localhost
 
 3. Place the generated `localhost.pem` and `localhost-key.pem` files in the root directory of your project.
 
+##### When using `ngrok-v1`
+
+> [!WARNING]
+> This feature is experimental.
+
+Before using the `serve` command, you need to install [ngrok](https://github.com/inconshreveable/ngrok) and [node-pty](https://www.npmjs.com/package/node-pty).
+
 #### Running the Server
 
 **Before proceeding, ensure that your LIFF app is running locally.** The `url` (or `host` and `port`) used in the following commands should correspond to your locally running LIFF app.
@@ -127,7 +136,8 @@ To start the server, use one of the following commands:
 ```sh
 $ liff-cli serve \
     --liff-id <liffId> \
-    --url <url>
+    --url <url> \
+    --proxy-type <local-proxy | ngrok-v1> \
     --inspect
 ```
 
@@ -136,8 +146,9 @@ or
 ```sh
 $ liff-cli serve \
     --liff-id <liffId> \
-    --host <host>
-    --port <port>
+    --host <host> \
+    --port <port> \
+    --proxy-type <local-proxy | ngrok-v1> \
     --inspect
 
 ```

--- a/src/serve/proxy/ngrok-v1-proxy.ts
+++ b/src/serve/proxy/ngrok-v1-proxy.ts
@@ -24,6 +24,9 @@ async function tryImportNodePty(): Promise<typeof pty> {
   }
 }
 
+/**
+ * @experimental
+ */
 export class NgrokV1Proxy implements ProxyInterface {
   private ptyProcess?: pty.IPty;
 

--- a/src/serve/resolveProxy.ts
+++ b/src/serve/resolveProxy.ts
@@ -33,6 +33,7 @@ export const resolveProxy = (
   }
 
   if (options.proxyType === "ngrok-v1") {
+    console.info("ngrok-v1 is experimental feature.");
     return {
       liffAppProxy: new NgrokV1Proxy({
         ngrokCommand: options.ngrokCommand,

--- a/src/serve/resolveProxy.ts
+++ b/src/serve/resolveProxy.ts
@@ -33,7 +33,7 @@ export const resolveProxy = (
   }
 
   if (options.proxyType === "ngrok-v1") {
-    console.info("ngrok-v1 is experimental feature.");
+    console.warn("ngrok-v1 is experimental feature.");
     return {
       liffAppProxy: new NgrokV1Proxy({
         ngrokCommand: options.ngrokCommand,


### PR DESCRIPTION
# Description
The [ngrok-v1](https://github.com/inconshreveable/ngrok) repository has been archived.
Therefore, we clarify that it is provided as an experimental feature so that it can be removed from `liff-cli` at any time.
