### PR TITLE
fix: Use current channel id when not specified from prompt

### DIFF
--- a/src/init/commands/index.test.ts
+++ b/src/init/commands/index.test.ts
@@ -73,6 +73,22 @@ describe("makeOptions", () => {
       endpointUrl: "https://localhost:9000",
     });
   });
+
+  it("should return channelId as undefined when not specified", async () => {
+    vi.mocked(inquire.prompt).mockResolvedValue({
+      channelId: "",
+      name: "My App",
+      viewType: "compact",
+      endpointUrl: "https://example.com",
+    });
+
+    const result = await makeOptions({});
+
+    expect(result).toEqual({
+      ...TEST_OPTIONS,
+      channelId: undefined,
+    });
+  });
 });
 
 describe("installInitCommands", async () => {

--- a/src/init/commands/index.ts
+++ b/src/init/commands/index.ts
@@ -13,7 +13,9 @@ export type InitOptions = {
 
 export async function makeOptions(
   options: InitOptions,
-): Promise<Required<InitOptions>> {
+): Promise<
+  Required<Omit<InitOptions, "channelId">> & Pick<InitOptions, "channelId">
+> {
   const promptItems = [];
 
   if (!options.channelId) {
@@ -54,7 +56,7 @@ export async function makeOptions(
   );
 
   return {
-    channelId: options.channelId ?? promptInputs.channelId,
+    channelId: options.channelId ?? (promptInputs.channelId || undefined),
     name: options.name ?? promptInputs.name,
     viewType: options.viewType ?? promptInputs.viewType,
     endpointUrl:

--- a/src/init/initAction.test.ts
+++ b/src/init/initAction.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import child_process from "child_process";
 import { initAction } from "./initAction.js";
+import { addAction as addChannelAction } from "../channel/commands/add.js";
 import { createLiffApp } from "../app/commands/create.js";
+import { resolveChannel } from "../channel/resolveChannel.js";
+import { makeOptions } from "./commands/index.js";
 
 vi.mock("../channel/commands/add.js");
+vi.mock("../channel/resolveChannel.js");
 vi.mock("../app/commands/create.js");
+vi.mock("./commands/index.js");
 vi.mock("child_process");
 vi.mock("inquirer");
 
@@ -16,9 +21,12 @@ const TEST_OPTIONS = {
 };
 
 describe("initAction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   it("should call execSync with correct command", async () => {
     vi.mocked(child_process.execSync).mockReturnValue(Buffer.from(""));
-
+    vi.mocked(makeOptions).mockResolvedValue(TEST_OPTIONS);
     const DUMMY_LIFF_ID = "hogehoge123";
     vi.mocked(createLiffApp).mockResolvedValue(DUMMY_LIFF_ID);
 
@@ -28,5 +36,32 @@ describe("initAction", () => {
       `npx @line/create-liff-app "${TEST_OPTIONS.name}" -l ${DUMMY_LIFF_ID}`,
       { stdio: "inherit" },
     );
+  });
+
+  it("should add channel if not registered", async () => {
+    vi.mocked(createLiffApp).mockResolvedValue("123");
+    vi.mocked(resolveChannel).mockResolvedValue(undefined);
+    vi.mocked(makeOptions).mockResolvedValue(TEST_OPTIONS);
+
+    await initAction({});
+
+    expect(resolveChannel).toBeCalled();
+    expect(addChannelAction).toHaveBeenCalledWith("123");
+  });
+
+  it("should not add channel if already registered", async () => {
+    vi.mocked(createLiffApp).mockResolvedValue("123");
+    vi.mocked(resolveChannel).mockResolvedValue({
+      secret: "secret",
+      accessToken: "accessToken",
+      expiresIn: 1000,
+      issuedAt: 2000,
+    });
+    vi.mocked(makeOptions).mockResolvedValue(TEST_OPTIONS);
+
+    await initAction({});
+
+    expect(resolveChannel).toBeCalled();
+    expect(addChannelAction).not.toBeCalled();
   });
 });


### PR DESCRIPTION
# Description
The description for the `--channel-id` option of `liff init` says `The channel ID to use. If it isn't specified, the currentChannelId will be used.`  
However, there was no implementation to reference the `currentChannelId` if a channel ID was not specified.
I added a feature to reference the `currentChannelId`.