### PR TITLE
fix: Improve error handling messages in LIFF API client

### DIFF
--- a/src/api/liff.test.ts
+++ b/src/api/liff.test.ts
@@ -31,10 +31,14 @@ describe("fetchApps", () => {
   it("should throw an error when the request fails", async () => {
     server.use(
       http.get(`${baseUrl}/liff/v1/apps`, () => {
-        return HttpResponse.json(undefined, {
-          status: 404,
-          statusText: "Not Found",
-        });
+        return HttpResponse.json(
+          {
+            message: "no LIFF app found for channel channelId.",
+          },
+          {
+            status: 404,
+          },
+        );
       }),
     );
 
@@ -43,7 +47,11 @@ describe("fetchApps", () => {
       token,
     });
     await expect(client.fetchApps()).rejects.toThrow(
-      "Failed to fetch LIFF apps: 404 Not Found",
+      `
+Failed to fetch LIFF apps.
+Code: 404
+Message: no LIFF app found for channel channelId.
+      `,
     );
   });
 });
@@ -69,10 +77,14 @@ describe("addApp", () => {
   it("should throw an error when the request fails", async () => {
     server.use(
       http.post(`${baseUrl}/liff/v1/apps`, async () => {
-        return HttpResponse.json(undefined, {
-          status: 400,
-          statusText: "Bad Request",
-        });
+        return HttpResponse.json(
+          {
+            message: "Invali value",
+          },
+          {
+            status: 400,
+          },
+        );
       }),
     );
 
@@ -82,7 +94,11 @@ describe("addApp", () => {
     });
     await expect(
       client.addApp({ view: { type: "full", url: "https://example.com" } }),
-    ).rejects.toThrow("Failed to add LIFF app: 400 Bad Request");
+    ).rejects.toThrow(`
+Failed to add LIFF app.
+Code: 400
+Message: Invali value
+      `);
   });
 });
 
@@ -107,10 +123,14 @@ describe("updateApp", () => {
   it("should throw an error when the request fails", async () => {
     server.use(
       http.put(`${baseUrl}/liff/v1/apps/liffId`, async () => {
-        return HttpResponse.json(undefined, {
-          status: 400,
-          statusText: "Bad Request",
-        });
+        return HttpResponse.json(
+          {
+            message: "Invali value",
+          },
+          {
+            status: 400,
+          },
+        );
       }),
     );
 
@@ -122,7 +142,11 @@ describe("updateApp", () => {
       client.updateApp("liffId", {
         view: { type: "full", url: "https://example.com" },
       }),
-    ).rejects.toThrow("Failed to update LIFF app: 400 Bad Request");
+    ).rejects.toThrow(`
+Failed to update LIFF app.
+Code: 400
+Message: Invali value
+`);
   });
 });
 
@@ -145,10 +169,15 @@ describe("deleteApp", () => {
   it("should throw an error when the request fails", async () => {
     server.use(
       http.delete(`${baseUrl}/liff/v1/apps/liffId`, () => {
-        return HttpResponse.json(undefined, {
-          status: 400,
-          statusText: "Bad Request",
-        });
+        return HttpResponse.json(
+          {
+            message: "Not found",
+          },
+          {
+            status: 400,
+            statusText: "Bad Request",
+          },
+        );
       }),
     );
 
@@ -156,8 +185,10 @@ describe("deleteApp", () => {
       baseUrl,
       token,
     });
-    await expect(client.deleteApp("liffId")).rejects.toThrow(
-      "Failed to delete LIFF app: 400 Bad Request",
-    );
+    await expect(client.deleteApp("liffId")).rejects.toThrow(`
+Failed to delete LIFF app.
+Code: 400
+Message: Not found
+`);
   });
 });

--- a/src/api/liff.ts
+++ b/src/api/liff.ts
@@ -29,9 +29,12 @@ export class LiffApiClient {
       },
     });
     if (!res.ok) {
-      throw new Error(
-        `Failed to fetch LIFF apps: ${res.status} ${res.statusText}`,
-      );
+      const errorRes = await res.json();
+      throw new Error(`
+Failed to fetch LIFF apps.
+Code: ${res.status}
+Message: ${errorRes.message}
+        `);
     }
     return res.json();
   }
@@ -50,9 +53,12 @@ export class LiffApiClient {
       body: JSON.stringify(request),
     });
     if (!res.ok) {
-      throw new Error(
-        `Failed to add LIFF app: ${res.status} ${res.statusText}`,
-      );
+      const errorRes = await res.json();
+      throw new Error(`
+Failed to add LIFF app.
+Code: ${res.status}
+Message: ${errorRes.message}
+        `);
     }
     return res.json();
   }
@@ -74,9 +80,12 @@ export class LiffApiClient {
       },
     );
     if (!res.ok) {
-      throw new Error(
-        `Failed to update LIFF app: ${res.status} ${res.statusText}`,
-      );
+      const errorRes = await res.json();
+      throw new Error(`
+Failed to update LIFF app.
+Code: ${res.status}
+Message: ${errorRes.message}
+        `);
     }
   }
 
@@ -92,9 +101,12 @@ export class LiffApiClient {
       },
     );
     if (!res.ok) {
-      throw new Error(
-        `Failed to delete LIFF app: ${res.status} ${res.statusText}`,
-      );
+      const errorRes = await res.json();
+      throw new Error(`
+Failed to delete LIFF app.
+Code: ${res.status}
+Message: ${errorRes.message}
+        `);
     }
   }
 }


### PR DESCRIPTION
## Summary
The PR changes all API methods (fetchApps, addApp, updateApp, deleteApp) to parse the error response body and format errors with both status code and the specific error message returned from the server, rather than just showing HTTP status codes and generic status text.

#### ASIS 
```sh
$ liff-cli app delete -l a
? Are you sure you want to delete this? Yes
Deleting LIFF app...
file:///Users/jp30522/github/oss/liff-cli/dist/api/liff.js:61
            throw new Error(`Failed to delete LIFF app: ${res.status} ${res.statusText}`);
                  ^

Error: Failed to delete LIFF app: 404 Not Found
    at LiffApiClient.deleteApp (file:///Users/jp30522/github/oss/liff-cli/dist/api/liff.js:61:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Command.deleteAction (file:///Users/jp30522/github/oss/liff-cli/dist/app/commands/delete.js:27:5)
```

#### TOBE
```sh
$ liff-cli app delete -l a
? Are you sure you want to delete this? Yes
Deleting LIFF app...
file:///Users/jp30522/github/oss/liff-cli/dist/api/liff.js:77
            throw new Error(`
                  ^

Error:
Failed to delete LIFF app.
Code: 404
Message: LIFF app 'a' was not found.

    at LiffApiClient.deleteApp (file:///Users/jp30522/github/oss/liff-cli/dist/api/liff.js:77:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Command.deleteAction (file:///Users/jp30522/github/oss/liff-cli/dist/app/commands/delete.js:27:5)
```