### PR TITLE
ci: Pin version of GitHub Actions using SHA

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version-file: ./.nvmrc
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,17 +14,17 @@ jobs:
     environment:
       name: Production
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           node-version-file: ./.nvmrc
 
       - run: npm ci
       - run: node --run build
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2
         with:
           registry-url: https://registry.npmjs.org
 

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
To mitigate supply chain attacks in GitHub Actions, I pinned the version of GitHub Actions using SHA.
https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/