### PR TITLE
docs: update README to include '--ngrok-command' flag for ngrok v1 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ To start the server, use one of the following commands:
 $ liff-cli serve \
     --liff-id <liffId> \
     --url <url> \
-    --proxy-type <local-proxy | ngrok-v1>
+    --proxy-type <local-proxy | ngrok-v1> \
+    --inspect \
+    --ngrok-command <ngrokCommand>
 ```
 
 or
@@ -161,8 +163,9 @@ $ liff-cli serve \
     --liff-id <liffId> \
     --host <host> \
     --port <port> \
-    --proxy-type <local-proxy | ngrok-v1>
-
+    --proxy-type <local-proxy | ngrok-v1> \
+    --inspect \
+    --ngrok-command <ngrokCommand>
 ```
 
 ## Development


### PR DESCRIPTION
Hello! I found an area that could be corrected and created a PR! If these changes do not align with your vision, please feel free to close this PR.

## PR Overview
This PR updates the README for the ngrok v1 integration. Although the `--ngrok-command` option has already been implemented, it was missing from the documentation. With this update, users are now informed about the existence of this option and how to use it.

Updated Command Examples

Using URL:

```shell
$ liff-cli serve \
    --liff-id <liffId> \
    --url <url> \
    --proxy-type <local-proxy | ngrok-v1> \
    --ngrok-command ngrok
```
Using host and port:

```shell
$ liff-cli serve \
    --liff-id <liffId> \
    --host <host> \
    --port <port> \
    --proxy-type <local-proxy | ngrok-v1> \
    --ngrok-command ngrok
```