### PR TITLE
fix: Remove `await` from `listener.forward()` on NgrokProxy class

### DIFF
--- a/src/serve/proxy/ngrok-proxy.ts
+++ b/src/serve/proxy/ngrok-proxy.ts
@@ -34,7 +34,7 @@ export class NgrokProxy implements ProxyInterface {
       throw new Error("ngrok did not provide a URL");
     }
 
-    await listener.forward(`${targetHost}:${targetPort}`);
+    listener.forward(`${targetHost}:${targetPort}`);
 
     return new URL(url);
   }


### PR DESCRIPTION
To prevent subsequent processing from stopping, I removed `await` from the call to `listener.forward()` in the NgrokProxy class.

## Reason

[`listener.forward()`](https://ngrok.github.io/ngrok-javascript/classes/Listener.html#forward) returns a Promise, but this Promise does not seem to resolve until the forwarding task is complete. Therefore, using `await` causes subsequent processing to stop, and the CLI no longer works properly.

In fact, when the following command was executed in the current main branch, nothing was output to the terminal:

```
$ liff-cli serve \
  --liff-id 1234567890-AbcdEfgh \
  --url http://localhost:5173 \
  --proxy-type ngrok

(no output)
```

Internally, the endpoint was created on Ngrok, but the endpoint URL on the LINE Developers Console was not updated.

In the official documentation sample, `listener.forward()` is also called without `await`:

```javascript
async function create_listener() {
  const session = await new ngrok.NgrokSessionBuilder().authtokenFromEnv().connect();
  const listener = await session.httpEndpoint().listen();
  console.log("Ingress established at:", listener.url());
  listener.forward("localhost:8081");
}
```

https://github.com/ngrok/ngrok-javascript?tab=readme-ov-file#builders

After removing `await`, ngrok processed normally, and the endpoint URL on the LINE Developers Console was also updated.