### PR TITLE
add `@deprecated` to NgrokV1Proxy

### DIFF
--- a/src/serve/proxy/ngrok-v1-proxy.ts
+++ b/src/serve/proxy/ngrok-v1-proxy.ts
@@ -25,7 +25,7 @@ async function tryImportNodePty(): Promise<typeof pty> {
 }
 
 /**
- * @experimental
+ * @deprecated
  */
 export class NgrokV1Proxy implements ProxyInterface {
   private ptyProcess?: pty.IPty;

--- a/src/serve/resolveProxy.ts
+++ b/src/serve/resolveProxy.ts
@@ -34,7 +34,9 @@ export const resolveProxy = (
   }
 
   if (options.proxyType === "ngrok-v1") {
-    console.warn("ngrok-v1 is experimental feature.");
+    console.warn(
+      `proxyType 'ngrok-v1' is deprecated. Please use 'ngrok' instead.`,
+    );
     return {
       liffAppProxy: new NgrokV1Proxy({
         ngrokCommand: options.ngrokCommand,


### PR DESCRIPTION
In https://github.com/line/liff-cli/pull/17, the LIFF CLI gained support for the latest version of ngrok.  
Therefore, there is no longer any need to use the older version, `ngrok-v1`.