### PR TITLE
fix: ngrok proxy endpoint URL handling

### DIFF
--- a/src/serve/proxy/ngrok-proxy.ts
+++ b/src/serve/proxy/ngrok-proxy.ts
@@ -8,7 +8,8 @@ export class NgrokProxy implements ProxyInterface {
   constructor() {}
 
   async connect(targetUrl: URL): Promise<URL> {
-    const targetPort = targetUrl.port || (targetUrl.protocol === "https:" ? "443" : "80");
+    const targetPort =
+      targetUrl.port || (targetUrl.protocol === "https:" ? "443" : "80");
     const targetHost = targetUrl.hostname;
 
     if (!process.env.NGROK_AUTHTOKEN) {

--- a/src/serve/proxy/ngrok-proxy.ts
+++ b/src/serve/proxy/ngrok-proxy.ts
@@ -39,6 +39,7 @@ export class NgrokProxy implements ProxyInterface {
     const urlWithPath = new URL(url);
     urlWithPath.pathname = targetUrl.pathname;
     urlWithPath.search = targetUrl.search;
+    urlWithPath.hash = targetUrl.hash;
     return urlWithPath;
   }
 

--- a/src/serve/proxy/ngrok-proxy.ts
+++ b/src/serve/proxy/ngrok-proxy.ts
@@ -36,7 +36,10 @@ export class NgrokProxy implements ProxyInterface {
 
     listener.forward(`${targetHost}:${targetPort}`);
 
-    return new URL(url);
+    const urlWithPath = new URL(url);
+    urlWithPath.pathname = targetUrl.pathname;
+    urlWithPath.search = targetUrl.search;
+    return urlWithPath;
   }
 
   async cleanup(): Promise<void> {

--- a/src/serve/proxy/ngrok-proxy.ts
+++ b/src/serve/proxy/ngrok-proxy.ts
@@ -8,7 +8,7 @@ export class NgrokProxy implements ProxyInterface {
   constructor() {}
 
   async connect(targetUrl: URL): Promise<URL> {
-    const targetPort = targetUrl.port;
+    const targetPort = targetUrl.port || (targetUrl.protocol === "https:" ? "443" : "80");
     const targetHost = targetUrl.hostname;
 
     if (!process.env.NGROK_AUTHTOKEN) {


### PR DESCRIPTION
# Fix ngrok proxy endpoint URL handling

- ensure ngrok forwarding always uses an explicit port by defaulting to `80`/`443` based on the incoming scheme  
- preserve the original endpoint `pathname` and query string when constructing the public tunnel URL so LIFF keeps non-root routes

## Testing
- `liff-cli serve --proxy-type ngrok --url http://localhost/liff/some/path`
